### PR TITLE
attempted to add better OOM feedback 

### DIFF
--- a/tensor2tensor/layers/common_layers.py
+++ b/tensor2tensor/layers/common_layers.py
@@ -39,6 +39,30 @@ from tensorflow.python.framework import ops
 # This is a global setting. When turned off, no @function.Defun is used.
 allow_defun = False
 
+def dropout_with_broadcast_dims(x, keep_prob, broadcast_dims=None, **kwargs):
+  """Like tf.nn.dropout but takes broadcast_dims instead of noise_shape.
+  Instead of specifying noise_shape, this function takes broadcast_dims -
+  a list of dimension numbers in which noise_shape should be 1.  The random
+  keep/drop tensor has dimensionality 1 along these dimensions.
+  Args:
+    x: a floating point tensor.
+    keep_prob: A scalar Tensor with the same type as x.
+      The probability that each element is kept.
+    broadcast_dims: an optional list of integers
+      the dimensions along which to broadcast the keep/drop flags.
+    **kwargs: keyword arguments to tf.nn.dropout other than "noise_shape".
+  Returns:
+    A Tensor with the same size and shape as x.
+  """
+  assert "noise_shape" not in kwargs
+  if broadcast_dims:
+    shape = tf.shape(x)
+    ndims = len(x.get_shape())
+    kwargs["noise_shape"] = [
+        1 if i in broadcast_dims else shape[i] for i in xrange(ndims)]
+  return tf.nn.dropout(x, keep_prob, **kwargs)
+
+
 
 def saturating_sigmoid(x):
   """Saturating sigmoid: 1.2 * sigmoid(x) - 0.1 cut to [0, 1]."""

--- a/tensor2tensor/utils/trainer_lib.py
+++ b/tensor2tensor/utils/trainer_lib.py
@@ -194,8 +194,15 @@ class MemoryReportingHook(SessionRunHook):
         session_args = run_context.original_args
         # '2' == 'options'
         print ('SESSION ARGS ARE', session_args)
-        session_args[2].report_tensor_allocations_upon_oom = True
-        return args
+
+        if session_args[2]:
+            session_args[2].report_tensor_allocations_upon_oom = True
+        else:
+            session_args[2] = tf.RunOptions(
+                report_tensor_allocations_upon_oom=True)
+        print ('SESSION ARGS NOW ARE', session_args)
+
+        return session_args
 
 def create_hooks(use_tfdbg=False, use_dbgprofile=False, dbgprofile_kwargs=None,
                  use_validation_monitor=False, validation_monitor_kwargs=None,

--- a/tensor2tensor/utils/trainer_lib.py
+++ b/tensor2tensor/utils/trainer_lib.py
@@ -192,6 +192,17 @@ def create_estimator(model_name,
 class MemoryReportingHook(SessionRunHook):
     """
     In theory this should work...doesn't seem to, however...
+
+    Based on https://stackoverflow.com/questions/45719176/how-to-display-runtime-statistics-in-tensorboard-using-estimator-api-in-a-distri.
+
+    TF, when OOM occurs, talks about setting 
+    report_tensor_allocations_upon_oom=True to get more diagnostics.
+
+    When running things through Estimator/Experiment, however,
+    is very unclear how to do so, unfortunately.
+
+    The below was an attempt.  Leaving it in, for now, because it seems like
+    it *should* work.
     """
 
     def before_run(self, run_context):
@@ -232,8 +243,6 @@ def create_hooks(use_tfdbg=False, use_dbgprofile=False, dbgprofile_kwargs=None,
     defaults.update(dbgprofile_kwargs)
     train_monitors.append(tf.contrib.hooks.ProfilerHook(**defaults))
 
-  # OOM
-
   if use_validation_monitor:
     # Fathom
     # continuous_train_and_eval breaks early stopping
@@ -251,8 +260,12 @@ def create_hooks(use_tfdbg=False, use_dbgprofile=False, dbgprofile_kwargs=None,
     train_monitors.append(hook)
     eval_hooks.append(hook)
   
-  train_monitors.append(MemoryReportingHook())
-  eval_hooks.append(MemoryReportingHook())
+  # NOTE:
+  # Attempt at adding better OOM feedback--although doesn't seem to work.
+  # (See MemoryReportingHook)
+  # Commenting this out for now because it doens't seem to actually work...
+  #train_monitors.append(MemoryReportingHook())
+  #eval_hooks.append(MemoryReportingHook())
 
 
   return train_monitors, eval_hooks

--- a/tensor2tensor/utils/trainer_lib.py
+++ b/tensor2tensor/utils/trainer_lib.py
@@ -32,6 +32,7 @@ from tensor2tensor.utils import registry
 from tensor2tensor.utils import t2t_model
 
 import tensorflow as tf
+from tensorflow.python.training.session_run_hook import SessionRunHook
 
 from tensorflow.core.protobuf import rewriter_config_pb2
 from tensorflow.python import debug

--- a/tensor2tensor/utils/trainer_lib.py
+++ b/tensor2tensor/utils/trainer_lib.py
@@ -238,7 +238,7 @@ def create_hooks(use_tfdbg=False, use_dbgprofile=False, dbgprofile_kwargs=None,
     # continuous_train_and_eval breaks early stopping
     flags = tf.flags
     FLAGS = flags.FLAGS
-    assert FLAGS.schedule != 'continuous_train_and_eval'
+    #assert FLAGS.schedule != 'continuous_train_and_eval'
     
     train_monitors.append(
         tf.contrib.learn.monitors.ValidationMonitor(

--- a/tensor2tensor/utils/trainer_lib.py
+++ b/tensor2tensor/utils/trainer_lib.py
@@ -248,7 +248,7 @@ def create_hooks(use_tfdbg=False, use_dbgprofile=False, dbgprofile_kwargs=None,
     # continuous_train_and_eval breaks early stopping
     flags = tf.flags
     FLAGS = flags.FLAGS
-    #assert FLAGS.schedule != 'continuous_train_and_eval'
+    assert FLAGS.schedule != 'continuous_train_and_eval'
     
     train_monitors.append(
         tf.contrib.learn.monitors.ValidationMonitor(

--- a/tensor2tensor/utils/trainer_lib.py
+++ b/tensor2tensor/utils/trainer_lib.py
@@ -192,7 +192,9 @@ def create_estimator(model_name,
 class MemoryReportingHook(SessionRunHook):
     def before_run(self, run_context):
         session_args = run_context.original_args
-        session_args['options'].report_tensor_allocations_upon_oom = True
+        # '2' == 'options'
+        print ('SESSION ARGS ARE', session_args)
+        session_args[2].report_tensor_allocations_upon_oom = True
         return args
 
 def create_hooks(use_tfdbg=False, use_dbgprofile=False, dbgprofile_kwargs=None,

--- a/tensor2tensor/utils/trainer_lib.py
+++ b/tensor2tensor/utils/trainer_lib.py
@@ -190,13 +190,15 @@ def create_estimator(model_name,
         model_fn=model_fn, model_dir=run_config.model_dir, config=run_config)
 
 class MemoryReportingHook(SessionRunHook):
+    """
+    In theory this should work...doesn't seem to, however...
+    """
+
     def before_run(self, run_context):
         session_args = run_context.original_args
         fetches = session_args.fetches
         feed_dict = session_args.feed_dict
         options = session_args.options
-        # '2' == 'options'
-        print ('SESSION ARGS ARE', session_args)
 
         # does this work?
         if options:
@@ -208,7 +210,6 @@ class MemoryReportingHook(SessionRunHook):
             fetches=fetches,
             feed_dict=feed_dict,
             options=options)
-        print ('SESSION ARGS NOW ARE', session_args)
 
         return session_args
 

--- a/tensor2tensor/utils/trainer_lib.py
+++ b/tensor2tensor/utils/trainer_lib.py
@@ -200,7 +200,7 @@ class MemoryReportingHook(SessionRunHook):
 
         # does this work?
         if options:
-            session_args[2].report_tensor_allocations_upon_oom = True
+            options.report_tensor_allocations_upon_oom = True
         else:
             options = tf.RunOptions(
                 report_tensor_allocations_upon_oom=True)
@@ -218,8 +218,6 @@ def create_hooks(use_tfdbg=False, use_dbgprofile=False, dbgprofile_kwargs=None,
   """Create train and eval hooks for Experiment."""
   train_monitors = []
   eval_hooks = []
-
-  train_monitors.append(MemoryReportingHook())
 
   if use_tfdbg:
     hook = debug.LocalCLIDebugHook()
@@ -251,6 +249,10 @@ def create_hooks(use_tfdbg=False, use_dbgprofile=False, dbgprofile_kwargs=None,
     # Adding to both training and eval so that eval aborts as well
     train_monitors.append(hook)
     eval_hooks.append(hook)
+  
+  train_monitors.append(MemoryReportingHook())
+  eval_hooks.append(MemoryReportingHook())
+
 
   return train_monitors, eval_hooks
 

--- a/tensor2tensor/utils/trainer_lib.py
+++ b/tensor2tensor/utils/trainer_lib.py
@@ -32,7 +32,7 @@ from tensor2tensor.utils import registry
 from tensor2tensor.utils import t2t_model
 
 import tensorflow as tf
-from tensorflow.python.training.session_run_hook import SessionRunHook
+from tensorflow.python.training.session_run_hook import SessionRunHook, SessionRunArgs
 
 from tensorflow.core.protobuf import rewriter_config_pb2
 from tensorflow.python import debug
@@ -192,14 +192,22 @@ def create_estimator(model_name,
 class MemoryReportingHook(SessionRunHook):
     def before_run(self, run_context):
         session_args = run_context.original_args
+        fetches = session_args.fetches
+        feed_dict = session_args.feed_dict
+        options = session_args.options
         # '2' == 'options'
         print ('SESSION ARGS ARE', session_args)
 
-        if session_args[2]:
+        # does this work?
+        if options:
             session_args[2].report_tensor_allocations_upon_oom = True
         else:
-            session_args[2] = tf.RunOptions(
+            options = tf.RunOptions(
                 report_tensor_allocations_upon_oom=True)
+        session_args = SessionRunArgs(
+            fetches=fetches,
+            feed_dict=feed_dict,
+            options=options)
         print ('SESSION ARGS NOW ARE', session_args)
 
         return session_args


### PR DESCRIPTION
Supposedly, report_tensor_allocations_upon_oom=True should give better information about tensors when GPU goes OOM.  

Tried the approach suggested by https://stackoverflow.com/questions/45719176/how-to-display-runtime-statistics-in-tensorboard-using-estimator-api-in-a-distri, doesn't seem to work.  Leaving this code in here since I think it mostly *should* work...can re-visit in the future.

Also added dropout func from current t2t.