### PR TITLE
Ability to define hparams_set for t2t_datagen and t2t_decode

### DIFF
--- a/tensor2tensor/bin/t2t_datagen.py
+++ b/tensor2tensor/bin/t2t_datagen.py
@@ -86,6 +86,8 @@ flags.DEFINE_string("t2t_usr_dir", "",
                     "e.g. @registry.register_problem calls, that will then be "
                     "available to t2t-datagen.")
 
+flags.DEFINE_string("hparams_set", None, "Which parameters to use.")
+
 
 # Mapping from problems that we can generate data for to their generators.
 # pylint: disable=g-long-lambda

--- a/tensor2tensor/bin/t2t_decoder.py
+++ b/tensor2tensor/bin/t2t_decoder.py
@@ -83,7 +83,6 @@ def create_decode_hparams():
 
 
 def decode(estimator, hparams, decode_hp):
-  # TODO: probably pass the hparams_set in the two first cases too
   if FLAGS.decode_interactive:
     decoding.decode_interactively(estimator, hparams, decode_hp)
   elif FLAGS.decode_from_file:
@@ -91,14 +90,12 @@ def decode(estimator, hparams, decode_hp):
                               decode_hp, FLAGS.decode_to_file)
   else:
 
-    print('==> t2t_decoder, about to decode_from_dataset: ', FLAGS.hparams_set)
     # Fathom
     predictions = decoding.decode_from_dataset(
       estimator,
       FLAGS.problems.split("-"),
       hparams,
       decode_hp,
-      hparams_set=FLAGS.hparams_set,
       decode_to_file=FLAGS.decode_to_file,
       dataset_split="test" if FLAGS.eval_use_test_set else None,
       return_generator=FLAGS.fathom_output_predictions)

--- a/tensor2tensor/bin/t2t_decoder.py
+++ b/tensor2tensor/bin/t2t_decoder.py
@@ -83,6 +83,7 @@ def create_decode_hparams():
 
 
 def decode(estimator, hparams, decode_hp):
+  # TODO: probably pass the hparams_set in the two first cases too
   if FLAGS.decode_interactive:
     decoding.decode_interactively(estimator, hparams, decode_hp)
   elif FLAGS.decode_from_file:
@@ -90,15 +91,17 @@ def decode(estimator, hparams, decode_hp):
                               decode_hp, FLAGS.decode_to_file)
   else:
 
+    print('==> t2t_decoder, about to decode_from_dataset: ', FLAGS.hparams_set)
     # Fathom
     predictions = decoding.decode_from_dataset(
-        estimator,
-        FLAGS.problems.split("-"),
-        hparams,
-        decode_hp,
-        decode_to_file=FLAGS.decode_to_file,
-        dataset_split="test" if FLAGS.eval_use_test_set else None,
-        return_generator=FLAGS.fathom_output_predictions)
+      estimator,
+      FLAGS.problems.split("-"),
+      hparams,
+      decode_hp,
+      hparams_set=FLAGS.hparams_set,
+      decode_to_file=FLAGS.decode_to_file,
+      dataset_split="test" if FLAGS.eval_use_test_set else None,
+      return_generator=FLAGS.fathom_output_predictions)
 
     # Fathom
     if FLAGS.fathom_output_predictions:

--- a/tensor2tensor/utils/decoding.py
+++ b/tensor2tensor/utils/decoding.py
@@ -100,6 +100,7 @@ def decode_from_dataset(estimator,
                         problem_names,
                         hparams,
                         decode_hp,
+                        hparams_set=None,
                         decode_to_file=None,
                         dataset_split=None,
                         return_generator=False):

--- a/tensor2tensor/utils/decoding.py
+++ b/tensor2tensor/utils/decoding.py
@@ -100,7 +100,6 @@ def decode_from_dataset(estimator,
                         problem_names,
                         hparams,
                         decode_hp,
-                        hparams_set=None,
                         decode_to_file=None,
                         dataset_split=None,
                         return_generator=False):


### PR DESCRIPTION
Goal: adding support for legacy DEID model trained on the non-DEID'd royal dataset.

Adding ability to define hparams_set for datagen and decode, hence support for deid legacy's inference.

Ref: associated diseaseTools PR is https://github.com/medicode/diseaseTools/pull/2227