### PR TITLE
make h5py unnecessary

### DIFF
--- a/tensor2tensor/data_generators/all_problems.py
+++ b/tensor2tensor/data_generators/all_problems.py
@@ -31,9 +31,9 @@ modules = [
     "tensor2tensor.data_generators.cnn_dailymail",
     "tensor2tensor.data_generators.desc2code",
     "tensor2tensor.data_generators.fsns",
-    "tensor2tensor.data_generators.gene_expression",
     # FATHOM
-    # remove gym dependency
+    # remove h5py and gym dependencies
+    #"tensor2tensor.data_generators.gene_expression",
     #"tensor2tensor.data_generators.gym",
     "tensor2tensor.data_generators.ice_parsing",
     "tensor2tensor.data_generators.imagenet",


### PR DESCRIPTION
Necessary to fix smoke tests, we think