### PR TITLE
code elsewhere now

### DIFF
--- a/tensor2tensor/utils/metrics.py
+++ b/tensor2tensor/utils/metrics.py
@@ -399,39 +399,6 @@ def roc_auc(logits, labels, weights_fn=None):
     return auc, tf.constant(1.0)
 
 
-def set_auc(predictions,
-            labels,
-            weights_fn=common_layers.weights_nonzero):
-  """AUC of set predictions.
-
-  Args:
-    predictions : A Tensor of scores of shape (batch, nlabels)
-    labels: A Tensor of int32s giving true set elements of shape (batch, seq_length)
-
-  Returns:
-    hits: A Tensor of shape (batch, nlabels)
-    weights: A Tensor of shape (batch, nlabels)
-  """
-  with tf.variable_scope("set_auc", values=[predictions, labels]):
-    labels = tf.squeeze(labels, [2, 3])
-    labels = tf.one_hot(labels, predictions.shape[-1] + 1)
-    labels = tf.reduce_max(labels, axis=1)
-    # gah this is so hacky, now we suppress empty sets...
-    weights = tf.reduce_max(labels[:, 1:], axis=1, keep_dims=True)
-    labels = tf.cast(labels, tf.bool)
-    labels = labels[:, 1:]
-    predictions = tf.nn.sigmoid(predictions)
-    auc, update_op = tf.metrics.auc(labels=labels,
-                                    predictions=predictions,
-                                    weights=weights,
-                                    curve='PR')
-
-    with tf.control_dependencies([update_op]):
-      auc = tf.identity(auc)
-
-    return auc, tf.constant(1.0)
-
-
 def create_evaluation_metrics(problems, model_hparams):
   """Creates the evaluation metrics for the model.
 


### PR DESCRIPTION
Code in https://github.com/medicode/diseaseTools/blob/b3b7e50b4dde6c721283d249d80942e6c3b1e904/fathomt2t_dependencies/fh_metrics.py#L4.

We already import this function, anyway (at https://github.com/medicode/tensor2tensor/blob/master/tensor2tensor/utils/metrics.py#L36), but neglected to remove old code.