### PR TITLE
Fix/decode eval permissions

### DIFF
--- a/tensor2tensor/bin/t2t_decoder.py
+++ b/tensor2tensor/bin/t2t_decoder.py
@@ -126,6 +126,9 @@ def decode(estimator, hparams, decode_hp):
         decode_to_file=FLAGS.decode_to_file,
         dataset_split=dataset_to_t2t_mode(FLAGS.dataset_split),
         return_generator=FLAGS.fathom_output_predictions,
+        # save logs/summaries to same directory as decode_output_file
+        # in situations where we are calling decode without write permissions
+        # to the model directory
         output_dir=os.path.splitext(FLAGS.decode_output_file)[0])
 
     # Fathom

--- a/tensor2tensor/bin/t2t_decoder.py
+++ b/tensor2tensor/bin/t2t_decoder.py
@@ -126,7 +126,7 @@ def decode(estimator, hparams, decode_hp):
         decode_to_file=FLAGS.decode_to_file,
         dataset_split=dataset_to_t2t_mode(FLAGS.dataset_split),
         return_generator=FLAGS.fathom_output_predictions,
-        # save logs/summaries to same directory as decode_output_file
+        # save logs/summaries to a directory with the same name as decode_output_file
         # in situations where we are calling decode without write permissions
         # to the model directory
         output_dir=os.path.splitext(FLAGS.decode_output_file)[0])

--- a/tensor2tensor/bin/t2t_decoder.py
+++ b/tensor2tensor/bin/t2t_decoder.py
@@ -125,7 +125,8 @@ def decode(estimator, hparams, decode_hp):
         decode_hp,
         decode_to_file=FLAGS.decode_to_file,
         dataset_split=dataset_to_t2t_mode(FLAGS.dataset_split),
-        return_generator=FLAGS.fathom_output_predictions)
+        return_generator=FLAGS.fathom_output_predictions,
+        output_dir=os.path.dirname(FLAGS.decode_to_file))
 
     # Fathom
     if FLAGS.fathom_output_predictions:

--- a/tensor2tensor/bin/t2t_decoder.py
+++ b/tensor2tensor/bin/t2t_decoder.py
@@ -126,7 +126,7 @@ def decode(estimator, hparams, decode_hp):
         decode_to_file=FLAGS.decode_to_file,
         dataset_split=dataset_to_t2t_mode(FLAGS.dataset_split),
         return_generator=FLAGS.fathom_output_predictions,
-        output_dir=os.path.dirname(FLAGS.decode_to_file))
+        output_dir=os.path.splitext(FLAGS.decode_output_file)[0])
 
     # Fathom
     if FLAGS.fathom_output_predictions:

--- a/tensor2tensor/utils/decoding.py
+++ b/tensor2tensor/utils/decoding.py
@@ -142,7 +142,12 @@ def decode_from_dataset(estimator,
                         decode_hp,
                         decode_to_file=None,
                         dataset_split=None,
-                        return_generator=False):
+                        return_generator=False,
+                        # Fathom
+                        # otherwise decoding summary and logs are dumped
+                        # to the model directory whenever decoding happens.
+                        # should only be unspecified for eval.
+                        output_dir=None):
   """Decode from a dataset.
 
   Args:
@@ -161,7 +166,11 @@ def decode_from_dataset(estimator,
   shard = decode_hp.shard_id if decode_hp.shards > 1 else None
 
   # Setup decode output directory for any artifacts that may be written out
-  output_dir = os.path.join(estimator.model_dir, "decode")
+  # Fathom
+  # use passed in output_dir for writing decode summaries and logs
+  #output_dir = os.path.join(estimator.model_dir, "decode")
+  if not output_dir:
+    output_dir = os.path.join(estimator.model_dir, "decode")
   tf.gfile.MakeDirs(output_dir)
 
   # If decode_hp.batch_size is specified, use a fixed batch size

--- a/tensor2tensor/utils/t2t_model.py
+++ b/tensor2tensor/utils/t2t_model.py
@@ -1433,16 +1433,6 @@ class T2TModel(base.Layer):
         predictions[name] = feature
 
     _del_dict_non_tensors(predictions)
-
-    # Fathom
-    # allow model to emit additional outputs hardcoding in feature
-    # keys t2t uses
-    SKIP_FEATURES = ['inputs', 'targets', 'infer_targets', 'outputs', 'scores', 'problem_choice']
-    for k in infer_out:
-      if k in SKIP_FEATURES: continue
-      assert k not in predictions
-      predictions[k] = infer_out[k]
-
     
     export_out = {"outputs": predictions["outputs"]}
     if "scores" in predictions:


### PR DESCRIPTION
t2t issues
1) t2t now tries to create a folder `output_dir` during decode predictions for logs and summaries.  this is always into the model directory (this is a problem because currently prediction tasks can only read model directories and not write to them).  refer to https://github.com/medicode/tensor2tensor/blob/9ce9b9df21cd7982559e69aa0ec0e5985e078a5e/tensor2tensor/utils/decoding.py#L164
https://github.com/medicode/tensor2tensor/blob/9ce9b9df21cd7982559e69aa0ec0e5985e078a5e/tensor2tensor/utils/decoding.py#L208
https://github.com/medicode/tensor2tensor/blob/9ce9b9df21cd7982559e69aa0ec0e5985e078a5e/tensor2tensor/utils/decoding.py#L826


we only allow that if the decode is being called by `eval`, i.e. it only makes sense for any prediction logs / summaries ending up in a model's directory if it is evaluation of that model.  

if it is not eval, but a standalone prediction call, we don't record the logs / summaries in the same directory as the `decode_output_file` https://github.com/medicode/tensor2tensor/pull/96/files#diff-08abea4cee65e44adf3df1e34a4344a6R129

paired with https://github.com/medicode/diseaseTools/pull/2706

2)  t2t now passes features through prediction https://github.com/medicode/tensor2tensor/blob/9ce9b9df21cd7982559e69aa0ec0e5985e078a5e/tensor2tensor/utils/t2t_model.py#L1426, we don't need to handle it ourselves, in fact doing so ourselves clashes because of an assert we throw.