### PR TITLE
Add an exception for flag definition failure

### DIFF
--- a/tensor2tensor/bin/t2t_trainer.py
+++ b/tensor2tensor/bin/t2t_trainer.py
@@ -78,6 +78,9 @@ try:
                        "dataset once in full, whichever comes first, so this "
                        "can be a very large number.")
 except:  # pylint: disable=bare-except
+  # Fathom start
+  raise Exception('There was an issue defining t2t-trainer CLI flags')
+  # Fathom end
   pass
 
 # Google Cloud TPUs


### PR DESCRIPTION
So we don't have silent, mystery failures. @cbockman believes our t2t setup shouldn't hit this exception if things have been setup correctly