### PR TITLE
Bring back target modality multiple outputs support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,6 @@ dist/
 
 # Other
 *.DS_Store
+
+# Pycharm files
+.idea/

--- a/tensor2tensor/utils/t2t_model.py
+++ b/tensor2tensor/utils/t2t_model.py
@@ -1423,14 +1423,6 @@ class T2TModel(base.Layer):
         "targets": features.get("infer_targets"),
     }
 
-    # Fathom start
-    # pass through multiple outputs from target modality
-    if isinstance(infer_out, dict):
-      for key, value in infer_out.items():
-        if key not in predictions:
-          predictions[key] = value
-    # Fathom end
-
     # Pass through remaining features
     for name, feature in features.items():
       if name not in list(predictions.keys()) + ["infer_targets"]:
@@ -1439,6 +1431,14 @@ class T2TModel(base.Layer):
           batch_size = common_layers.shape_list(outputs)[0]
           feature = tf.tile(tf.expand_dims(feature, 0), [batch_size])
         predictions[name] = feature
+
+    # Fathom start
+    # pass through multiple outputs from target modality
+    if isinstance(infer_out, dict):
+      for key, value in infer_out.items():
+        if key not in predictions:
+          predictions[key] = value
+    # Fathom end
 
     _del_dict_non_tensors(predictions)
     

--- a/tensor2tensor/utils/t2t_model.py
+++ b/tensor2tensor/utils/t2t_model.py
@@ -1423,6 +1423,14 @@ class T2TModel(base.Layer):
         "targets": features.get("infer_targets"),
     }
 
+    # Fathom start
+    # pass through multiple outputs from target modality
+    if isinstance(infer_out, dict):
+      for key, value in infer_out.items():
+        if key not in predictions:
+          predictions[key] = value
+    # Fathom end
+
     # Pass through remaining features
     for name, feature in features.items():
       if name not in list(predictions.keys()) + ["infer_targets"]:


### PR DESCRIPTION
Was added in https://github.com/medicode/tensor2tensor/pull/7, but
removed in https://github.com/medicode/tensor2tensor/pull/96.

Tests in `diseaseTools` for this code path coming soon.

Manually tested in primary mode DAGs on dev + hipaa.