### PR TITLE
skip FATHOM_DICT_FORMAT

### DIFF
--- a/tensor2tensor/utils/t2t_model.py
+++ b/tensor2tensor/utils/t2t_model.py
@@ -223,7 +223,14 @@ class T2TModel(base.Layer):
 
       # Fathom
       if isinstance(sharded_logits, dict):
-        return {k:combine_shards(v) for k, v in sharded_logits.items()}, losses
+        return (
+            {
+                k: combine_shards(v)
+                for k, v in sharded_logits.items()
+                if k != FATHOM_DICT_FORMAT
+            },
+            losses
+        )
       else:
         return combine_shards(sharded_logits), losses
 

--- a/tensor2tensor/utils/t2t_model.py
+++ b/tensor2tensor/utils/t2t_model.py
@@ -223,6 +223,10 @@ class T2TModel(base.Layer):
 
       # Fathom
       if isinstance(sharded_logits, dict):
+        # skip FATHOM_DICT_FORMAT before passing to combine_shards
+        # TODO: figure out why this is needed here for multi gpu
+        # but handled inside combine_shards for 1 gpu
+        # https://app.asana.com/0/730593582890719/905516294620076/f
         return (
             {
                 k: combine_shards(v)


### PR DESCRIPTION
skips `FATHOM_DICT_FORMAT` boolean before `combine_shards` for multi gpu to run

TODO: figure out why this is required on top of `combine_shards` handling the same skip for single gpu.
https://app.asana.com/0/730593582890719/905516294620076/f