### PR TITLE
Revert/use resource

### DIFF
--- a/tensor2tensor/layers/common_hparams.py
+++ b/tensor2tensor/layers/common_hparams.py
@@ -67,10 +67,6 @@ def basic_params1():
       optimizer_adafactor_multiply_by_parameter_scale=True,
       # Number of accumulating steps for multi step optimizers.
       optimizer_multistep_accumulate_steps=None,
-      # Whether to zero gradients that were not computed, so that the
-      # appropriate slots are created. Useful for sharing checkpoints between
-      # models with different sets of heads.
-      optimizer_zero_grads=False,
       weight_decay=1e-6,
       weight_noise=0.0,
       # Defines the learning rate as a product of named functions.

--- a/tensor2tensor/utils/optimize.py
+++ b/tensor2tensor/utils/optimize.py
@@ -146,9 +146,9 @@ class ConditionalOptimizer(tf.train.Optimizer):
     # https://github.com/medicode/tensor2tensor/pull/130/files#diff-2b8e7a5e8b58c8e97ae722ba253dff43
     # preserve speed on gpus
     cast_grad = (
-        cast_grad_tpu
+        cast_grad_TPU
         if common_layers.is_xla_compiled()
-        else cast_grad_gpu)
+        else cast_grad_GPU)
     gradients = [cast_grad(g, v) for g, v in gradients]
     return gradients
 

--- a/tensor2tensor/utils/optimize.py
+++ b/tensor2tensor/utils/optimize.py
@@ -113,7 +113,7 @@ class ConditionalOptimizer(tf.train.Optimizer):
     else:
       self._opt = tf.contrib.layers.OPTIMIZER_CLS_NAMES[optimizer_name](lr)
 
-    self._zero_grads = hparams.optimizer_zero_grads
+      self._zero_grads = hparams.optimizer_zero_grads
 
   def compute_gradients(self, loss, var_list=None, **kwargs):  # pylint: disable=arguments-differ
     gradients = self._opt.compute_gradients(loss, var_list, **kwargs)

--- a/tensor2tensor/utils/optimize.py
+++ b/tensor2tensor/utils/optimize.py
@@ -113,18 +113,36 @@ class ConditionalOptimizer(tf.train.Optimizer):
     else:
       self._opt = tf.contrib.layers.OPTIMIZER_CLS_NAMES[optimizer_name](lr)
 
-      self._zero_grads = hparams.optimizer_zero_grads
-
   def compute_gradients(self, loss, var_list=None, **kwargs):  # pylint: disable=arguments-differ
     gradients = self._opt.compute_gradients(loss, var_list, **kwargs)
     def cast_grad(g, v):
-      if v is not None and g is not None:
-        g = common_layers.cast_like(g, v)
-      if self._zero_grads and g is None:
-        g = tf.zeros_like(v)
-      return (g, v)
+      """
+      below is old code.
+      need to test new to make sure it is still working
+      (word embedding slowdown problems)
+
+      can delete this block if runs OK
+
+      August 7 2018: We still need the code block below instead
+          Refer to https://github.com/tensorflow/tensor2tensor/issues/979.
+          We need `use_resource=False` in model_fn in utils/t2t_model.py
+          and the old version of cast_grad here.
+          Without both of these changes, we are very slow with
+          large word embeddings on the CPU.
+
+      """
+      if v is None or g is None:
+        return (g, v)
+      # Fathom: Ryan Sepassi said this would help
+      if v.dtype.base_dtype == g.dtype.base_dtype:
+        return (g, v)
+      return (tf.cast(g, v.dtype), v)
+      #if v is not None and g is not None:
+        #g = common_layers.cast_like(g, v)
+      #return (g, v)
     gradients = [cast_grad(g, v) for g, v in gradients]
     return gradients
+    # return self._opt.compute_gradients(loss, var_list, **kwargs)
 
   def apply_gradients(self, grads_and_vars, global_step=None, name=None):
     return self._opt.apply_gradients(

--- a/tensor2tensor/utils/optimize.py
+++ b/tensor2tensor/utils/optimize.py
@@ -117,38 +117,12 @@ class ConditionalOptimizer(tf.train.Optimizer):
 
   def compute_gradients(self, loss, var_list=None, **kwargs):  # pylint: disable=arguments-differ
     gradients = self._opt.compute_gradients(loss, var_list, **kwargs)
-    def cast_grad_tpu(g, v):
+    def cast_grad(g, v):
       if v is not None and g is not None:
         g = common_layers.cast_like(g, v)
       if self._zero_grads and g is None:
         g = tf.zeros_like(v)
       return (g, v)
-
-    def cast_grad_gpu(g, v):
-      """
-      August 7 2018: We still need the code block below instead
-          Refer to https://github.com/tensorflow/tensor2tensor/issues/979.
-          We need `use_resource=False` in model_fn in utils/t2t_model.py
-          and the old version of cast_grad here.
-          Without both of these changes, we are very slow with
-          large word embeddings on the CPU.
-
-      Sept 30 2019: We tried removing this since we are off word embeddings
-          but slowdown seems to still be around
-      """
-      if v is not None or g is None:
-        return (g, v)
-      if v.dtype.base_dtype == g.dtype.base_dtype:
-        return (g, v)
-      return (tf.cast(g, v.dtype), v)
-
-    # separate out tpu vs gpu cast grad so that changes in
-    # https://github.com/medicode/tensor2tensor/pull/130/files#diff-2b8e7a5e8b58c8e97ae722ba253dff43
-    # preserve speed on gpus
-    cast_grad = (
-        cast_grad_TPU
-        if common_layers.is_xla_compiled()
-        else cast_grad_GPU)
     gradients = [cast_grad(g, v) for g, v in gradients]
     return gradients
 

--- a/tensor2tensor/utils/t2t_model.py
+++ b/tensor2tensor/utils/t2t_model.py
@@ -327,11 +327,7 @@ class T2TModel(base.Layer):
     # Refer to https://github.com/tensorflow/tensor2tensor/issues/979.
     # We used to need `use_resource=False` here
     # but we don't use word embeddings on the CPU anymore
-    # NOTE: seems like there is still some slow down on GPU without word embeddings#
-    # use_resource = True when on TPU
-    # use_resource = False when on TPU
-    use_resource = common_layers.is_xla_compiled()
-    with tf.variable_scope(tf.get_variable_scope(), use_resource=use_resource) as vs:
+    with tf.variable_scope(tf.get_variable_scope(), use_resource=True) as vs:
       self._add_variable_scope("model_fn", vs)
       transformed_features = self.bottom(features)
 

--- a/tensor2tensor/utils/t2t_model.py
+++ b/tensor2tensor/utils/t2t_model.py
@@ -325,9 +325,12 @@ class T2TModel(base.Layer):
   def model_fn(self, features):
     # Fathom
     # Refer to https://github.com/tensorflow/tensor2tensor/issues/979.
-    # We used to need `use_resource=False` here
-    # but we don't use word embeddings on the CPU anymore
-    with tf.variable_scope(tf.get_variable_scope(), use_resource=True) as vs:
+    # We need `use_resource=False` here
+    # and the old version of cast_grad in utils/optimize.py
+    # Without both of these changes, we are very slow with
+    # large word embeddings on the CPU.
+    #with tf.variable_scope(tf.get_variable_scope(), use_resource=True) as vs:
+    with tf.variable_scope(tf.get_variable_scope(), use_resource=False) as vs:
       self._add_variable_scope("model_fn", vs)
       transformed_features = self.bottom(features)
 
@@ -1647,7 +1650,7 @@ def create_tpu_eval_metrics_fn(problem, model_hparams):
   """Create the metrics_fn that TPUEstimatorSpec expects."""
 
   metric_fns = []
-  eval_metrics = problem.eval_metric_fns(model_hparams)
+  eval_metrics = problem.eval_metrics()
 
   tm = problem.get_hparams(model_hparams).target_modality
   if isinstance(tm, dict):


### PR DESCRIPTION
revert #130, #131, #136, #137

these were all `use_resource` and `cast_grad` changes to be more inline with upstream for TPU and also account for speed reduction on GPU

but they are causing regressions in testinfra https://app.asana.com/0/911210587841072/1142311499808660/f 

revert so that we are back to a sane world.  tpu work can merge in what it needs to later