### PR TITLE
pull from feature/model_packing

### DIFF
--- a/tensor2tensor/bin/t2t_decoder.py
+++ b/tensor2tensor/bin/t2t_decoder.py
@@ -65,6 +65,7 @@ flags.DEFINE_bool("keep_timestamp", False,
 flags.DEFINE_bool("decode_interactive", False,
                   "Interactive local inference mode.")
 flags.DEFINE_integer("decode_shards", 1, "Number of decoding replicas.")
+flags.DEFINE_string("problems", "", "Problem to use in decode")
 flags.DEFINE_string("score_file", "", "File to score. Each line in the file "
                     "must be in the format input \t target.")
 # Fathom start

--- a/tensor2tensor/data_generators/problem.py
+++ b/tensor2tensor/data_generators/problem.py
@@ -1413,7 +1413,7 @@ def standardize_shapes(features, batch_size=None):
       t.get_shape().assert_is_fully_defined()
 
   for n, t in features.items():
-      tf.logging.info(f'Shape for {n}: {t}, {t.get_shape().as_list()}')
+      tf.logging.info(f'Standardized shape for {n}: {t}, {t.get_shape().as_list()}')
 
   return features
 

--- a/tensor2tensor/data_generators/problem.py
+++ b/tensor2tensor/data_generators/problem.py
@@ -1125,7 +1125,7 @@ class Problem(object):
 
     features:
         inputs_chunk_mask [num_chunks * max_docs_per_pack]
-        inputs_* [max_length
+        inputs_* [packed_length]
 
     """
     max_length = self.max_length(hparams)

--- a/tensor2tensor/data_generators/problem.py
+++ b/tensor2tensor/data_generators/problem.py
@@ -969,7 +969,6 @@ class Problem(object):
         # to specify the number of examples for all datashards
         # on GPU, num_shards specifies the number datashards and, thus in the
         # packed case, also the number of examples for all datashards
-        batch_size = params.get('batch_size', num_shards)
         if config and config.use_tpu:
           batch_size = params.get('batch_size')
           assert batch_size

--- a/tensor2tensor/data_generators/problem_test.py
+++ b/tensor2tensor/data_generators/problem_test.py
@@ -21,11 +21,12 @@ from __future__ import print_function
 
 import numpy as np
 
+from fathomt2t_dependencies.common_t2t_utils import pad_to_next_chunk_length
+
 from tensor2tensor.data_generators import algorithmic
 from tensor2tensor.data_generators import problem as problem_module
 from tensor2tensor.data_generators import problem_hparams
-from tensor2tensor.data_generators.problem import default_model_hparams, \
-  pad_inputs_to_chunk_len
+from tensor2tensor.data_generators.problem import default_model_hparams
 from tensor2tensor.layers import modalities
 from tensor2tensor.utils import registry
 
@@ -145,7 +146,7 @@ class ProblemTest(tf.test.TestCase):
       example = {'inputs': ex_1_inputs,
                'targets': ex1_targets}
 
-      padded_example = sess.run(pad_inputs_to_chunk_len(example, chunk_size))
+      padded_example = sess.run(pad_to_next_chunk_length(example, chunk_size))
       assert padded_example['inputs'].shape == (4, )
       # Should be unchanged
       assert padded_example['targets'].shape == (2, )

--- a/tensor2tensor/data_generators/problem_test.py
+++ b/tensor2tensor/data_generators/problem_test.py
@@ -141,13 +141,16 @@ class ProblemTest(tf.test.TestCase):
   def testChunkPadding(self):
     chunk_size = 4
     with tf.Session() as sess:
-      ex_1_inputs = tf.convert_to_tensor([0, 1 , 2])
+      ex_1_inputs = tf.convert_to_tensor([0, 1, 2])
       ex1_targets = tf.convert_to_tensor([2, 3])
       example = {'inputs': ex_1_inputs,
-               'targets': ex1_targets}
+                 'targets': ex1_targets}
 
       padded_example = sess.run(
-        pad_to_next_chunk_length(chunk_size, axis=0)(example))
+        pad_to_next_chunk_length(
+            chunk_length=chunk_size,
+            axis=0,
+            features_to_pad=['inputs'])(example))
       assert padded_example['inputs'].shape == (4, )
       # Should be unchanged
       assert padded_example['targets'].shape == (2, )

--- a/tensor2tensor/data_generators/problem_test.py
+++ b/tensor2tensor/data_generators/problem_test.py
@@ -146,7 +146,8 @@ class ProblemTest(tf.test.TestCase):
       example = {'inputs': ex_1_inputs,
                'targets': ex1_targets}
 
-      padded_example = sess.run(pad_to_next_chunk_length(example, chunk_size))
+      padded_example = sess.run(
+        pad_to_next_chunk_length(chunk_size, axis=0)(example))
       assert padded_example['inputs'].shape == (4, )
       # Should be unchanged
       assert padded_example['targets'].shape == (2, )


### PR DESCRIPTION
https://app.asana.com/0/1137246510213018/1141210948314505/f

paired with https://github.com/medicode/diseaseTools/pull/4905

1. for tpu (and packed gpu), we ensure that tensors are padded to a fixed length
2. nothing changes for gpu and chunked gpu runs