### PR TITLE
Support for eval on a specific checkpoint w/o export

### DIFF
--- a/tensor2tensor/bin/t2t_trainer.py
+++ b/tensor2tensor/bin/t2t_trainer.py
@@ -68,8 +68,8 @@ flags.DEFINE_integer("inter_op_parallelism_threads", 0,
 flags.DEFINE_integer("intra_op_parallelism_threads", 0,
                      "Number of intra_op_parallelism_threads to use for CPU. "
                      "See TensorFlow config.proto for details.")
-flags.DEFINE_string("checkpoint_path", None,
-                    "Path to the model checkpoint. Overrides output_dir.")
+flags.DEFINE_string("eval_checkpoint_path", None,
+                    "Use this path when doing eval")
 # TODO(hinsu): Enable DistributionStrategy by default once performance gap
 # between DistributionStrategy and Parallelism is resolved.
 flags.DEFINE_bool(

--- a/tensor2tensor/bin/t2t_trainer.py
+++ b/tensor2tensor/bin/t2t_trainer.py
@@ -69,7 +69,8 @@ flags.DEFINE_integer("intra_op_parallelism_threads", 0,
                      "Number of intra_op_parallelism_threads to use for CPU. "
                      "See TensorFlow config.proto for details.")
 flags.DEFINE_string("eval_checkpoint_path", None,
-                    "Use this path when doing eval")
+                    "The model path our trainer should do eval with. "
+                    "If set, model exporting after eval is disabled")
 # TODO(hinsu): Enable DistributionStrategy by default once performance gap
 # between DistributionStrategy and Parallelism is resolved.
 flags.DEFINE_bool(

--- a/tensor2tensor/bin/t2t_trainer.py
+++ b/tensor2tensor/bin/t2t_trainer.py
@@ -68,6 +68,8 @@ flags.DEFINE_integer("inter_op_parallelism_threads", 0,
 flags.DEFINE_integer("intra_op_parallelism_threads", 0,
                      "Number of intra_op_parallelism_threads to use for CPU. "
                      "See TensorFlow config.proto for details.")
+flags.DEFINE_string("checkpoint_path", None,
+                    "Path to the model checkpoint. Overrides output_dir.")
 # TODO(hinsu): Enable DistributionStrategy by default once performance gap
 # between DistributionStrategy and Parallelism is resolved.
 flags.DEFINE_bool(

--- a/tensor2tensor/utils/trainer_lib.py
+++ b/tensor2tensor/utils/trainer_lib.py
@@ -427,7 +427,6 @@ class T2TExperiment(object):
   def evaluate(self):
     flags = tf.flags
     FLAGS = flags.FLAGS
-    print(f"Path is {FLAGS.eval_checkpoint_path}")
     return self._estimator.evaluate(
         self._eval_spec.input_fn,
         steps=self._eval_spec.steps,

--- a/tensor2tensor/utils/trainer_lib.py
+++ b/tensor2tensor/utils/trainer_lib.py
@@ -425,10 +425,15 @@ class T2TExperiment(object):
         max_steps=max_steps or self._train_spec.max_steps)
 
   def evaluate(self):
+    flags = tf.flags
+    FLAGS = flags.FLAGS
+    print(f"Path is {FLAGS.checkpoint_path}")
     return self._estimator.evaluate(
         self._eval_spec.input_fn,
         steps=self._eval_spec.steps,
-        hooks=self._eval_spec.hooks)
+        hooks=self._eval_spec.hooks,
+        checkpoint_path=FLAGS.checkpoint_path,
+    )
 
   def evaluate_on_train_data(self):
     self._estimator.evaluate(

--- a/tensor2tensor/utils/trainer_lib.py
+++ b/tensor2tensor/utils/trainer_lib.py
@@ -427,12 +427,12 @@ class T2TExperiment(object):
   def evaluate(self):
     flags = tf.flags
     FLAGS = flags.FLAGS
-    print(f"Path is {FLAGS.checkpoint_path}")
+    print(f"Path is {FLAGS.eval_checkpoint_path}")
     return self._estimator.evaluate(
         self._eval_spec.input_fn,
         steps=self._eval_spec.steps,
         hooks=self._eval_spec.hooks,
-        checkpoint_path=FLAGS.checkpoint_path,
+        checkpoint_path=FLAGS.eval_checkpoint_path,
     )
 
   def evaluate_on_train_data(self):


### PR DESCRIPTION
Until now we could only run eval on the latest checkpoint and would always export after. This pr lets us eval on any checkpoint we want (as opposed to the most recent), and also lets us skip exporting when doing eval.

Sibling to https://github.com/medicode/diseaseTools/pull/5034

Asana task:
https://app.asana.com/0/823468737354222/1147720875716233