### PR TITLE
Fix zeroing our targets bug with packed problems

### DIFF
--- a/tensor2tensor/data_generators/problem.py
+++ b/tensor2tensor/data_generators/problem.py
@@ -155,6 +155,9 @@ def preprocess_example_common(example, hparams, mode):
     else:
       example["targets"] = tf.concat(
           [example["inputs"], [0], example["targets"]], 0)
+  # TODO: We should maybe refactor packed problems to not use max_target_seq_len
+  #   the way they currently do.
+  #   See https://app.asana.com/0/823468737354222/1149459228825153
   if hparams.max_target_seq_length > 0 and not hasattr(hparams, 'packed_length'):
     example["targets"] = example["targets"][:hparams.max_target_seq_length]
   if hparams.split_to_length:
@@ -963,6 +966,7 @@ class Problem(object):
         dataset = dataset.filter(tpu_valid_size)
         padded_shapes = self._pad_for_tpu(dataset.output_shapes, hparams)
         tf.logging.info(f'Padding features for fixed inputs: {padded_shapes}')
+
         # on TPU, params["batch_size"] is assigned in
         # https://github.com/medicode/tensor2tensor/blob/1525870c3a8ebc37240824a87532328e31d66887/tensor2tensor/utils/trainer_lib.py#L270
         # to specify the number of examples for all datashards

--- a/tensor2tensor/data_generators/problem.py
+++ b/tensor2tensor/data_generators/problem.py
@@ -40,7 +40,6 @@ from tensorflow.contrib.tpu.python.tpu import tpu_config
 
 import pretrained_models.bert.utilities as bert_utilities
 from fathomt2t_dependencies.common_t2t_utils import pad_to_next_chunk_length
-from fathomtf.utils.tfutils import debug_tfprint
 
 
 class DatasetSplit(object):
@@ -961,17 +960,7 @@ class Problem(object):
 
       # if dataset is packed (TPU requires packed dataset)
       if packed:
-        # def print_fn(x):
-          # x['targets'] = debug_tfprint(message="targets before are", tvar=x['targets'])
-          # x['inputs'] = debug_tfprint(message="inputs are", tvar=x['inputs'])
-          # return x
-        # dataset = dataset.map(print_fn)
         dataset = dataset.filter(tpu_valid_size)
-        # def print_fn(x):
-        #   x['targets'] = debug_tfprint(message="targets after are", tvar=x['targets'])
-        #   # x['inputs'] = debug_tfprint(message="inputs are", tvar=x['inputs'])
-        #   return x
-        # dataset = dataset.map(print_fn)
         padded_shapes = self._pad_for_tpu(dataset.output_shapes, hparams)
         tf.logging.info(f'Padding features for fixed inputs: {padded_shapes}')
         # on TPU, params["batch_size"] is assigned in

--- a/tensor2tensor/data_generators/problem.py
+++ b/tensor2tensor/data_generators/problem.py
@@ -40,6 +40,7 @@ from tensorflow.contrib.tpu.python.tpu import tpu_config
 
 import pretrained_models.bert.utilities as bert_utilities
 from fathomt2t_dependencies.common_t2t_utils import pad_to_next_chunk_length
+from fathomtf.utils.tfutils import debug_tfprint
 
 
 class DatasetSplit(object):
@@ -961,9 +962,12 @@ class Problem(object):
       # if dataset is packed (TPU requires packed dataset)
       if packed:
         dataset = dataset.filter(tpu_valid_size)
+        def print_fn(x):
+          x['targets'] = debug_tfprint(message="targets are", tvar=x['targets'])
+          return x
+        dataset = dataset.map(print_fn)
         padded_shapes = self._pad_for_tpu(dataset.output_shapes, hparams)
         tf.logging.info(f'Padding features for fixed inputs: {padded_shapes}')
-
         # on TPU, params["batch_size"] is assigned in
         # https://github.com/medicode/tensor2tensor/blob/1525870c3a8ebc37240824a87532328e31d66887/tensor2tensor/utils/trainer_lib.py#L270
         # to specify the number of examples for all datashards

--- a/tensor2tensor/data_generators/problem.py
+++ b/tensor2tensor/data_generators/problem.py
@@ -156,7 +156,7 @@ def preprocess_example_common(example, hparams, mode):
     else:
       example["targets"] = tf.concat(
           [example["inputs"], [0], example["targets"]], 0)
-  if hparams.max_target_seq_length > 0:
+  if hparams.max_target_seq_length > 0 and not hasattr(hparams, 'packed_length'):
     example["targets"] = example["targets"][:hparams.max_target_seq_length]
   if hparams.split_to_length:
     example["targets"] = tf.reshape(example["targets"],
@@ -961,11 +961,17 @@ class Problem(object):
 
       # if dataset is packed (TPU requires packed dataset)
       if packed:
+        # def print_fn(x):
+          # x['targets'] = debug_tfprint(message="targets before are", tvar=x['targets'])
+          # x['inputs'] = debug_tfprint(message="inputs are", tvar=x['inputs'])
+          # return x
+        # dataset = dataset.map(print_fn)
         dataset = dataset.filter(tpu_valid_size)
-        def print_fn(x):
-          x['targets'] = debug_tfprint(message="targets are", tvar=x['targets'])
-          return x
-        dataset = dataset.map(print_fn)
+        # def print_fn(x):
+        #   x['targets'] = debug_tfprint(message="targets after are", tvar=x['targets'])
+        #   # x['inputs'] = debug_tfprint(message="inputs are", tvar=x['inputs'])
+        #   return x
+        # dataset = dataset.map(print_fn)
         padded_shapes = self._pad_for_tpu(dataset.output_shapes, hparams)
         tf.logging.info(f'Padding features for fixed inputs: {padded_shapes}')
         # on TPU, params["batch_size"] is assigned in

--- a/tensor2tensor/utils/t2t_model.py
+++ b/tensor2tensor/utils/t2t_model.py
@@ -1515,6 +1515,7 @@ class T2TModel(base.Layer):
             # TODO: should be able to reshape from
             # [batch_size, max_target_seq_length] -> [batch_size, max_examples_per_pack, -1, 1, 1]
             # https://app.asana.com/0/1137246510213018/1143626077249177/f
+            print("RESHAPING TARGETS")
             features['targets'] = tf.reshape(
                 tensor=features['targets'],
                 shape=[-1, hparams.max_target_seq_length, 1, 1])

--- a/tensor2tensor/utils/t2t_model.py
+++ b/tensor2tensor/utils/t2t_model.py
@@ -1515,7 +1515,6 @@ class T2TModel(base.Layer):
             # TODO: should be able to reshape from
             # [batch_size, max_target_seq_length] -> [batch_size, max_examples_per_pack, -1, 1, 1]
             # https://app.asana.com/0/1137246510213018/1143626077249177/f
-            print("RESHAPING TARGETS")
             features['targets'] = tf.reshape(
                 tensor=features['targets'],
                 shape=[-1, hparams.max_target_seq_length, 1, 1])


### PR DESCRIPTION
See https://app.asana.com/0/823468737354222/1149459228825153 for more details.
Previously, when feeding packed examples through t2t, t2t would delete all the targets belonging to any doc after the first one in the pack. This led to our effective batch size always being 1, which in turn led to slow convergence.

This change stops t2t from deleting our targets

**Note:** The real issue here is a discrepancy between the semantics of the max_target_seq_length hparam in our code vs t2t's code. The asana task above is tracking the long term fix for this

Testing:
Prior to this fix we were unable to achieve parity on any dream run
After this fix, all our runs converge on train at least as fast as our benchmark