### PR TITLE
Fix/packed mocker fixes

### DIFF
--- a/tensor2tensor/bin/t2t_trainer.py
+++ b/tensor2tensor/bin/t2t_trainer.py
@@ -54,11 +54,6 @@ flags.DEFINE_integer("random_seed", None, "Random seed.")
 flags.DEFINE_integer("tpu_num_shards", 8, "Number of tpu shards.")
 flags.DEFINE_integer("iterations_per_loop", 100,
                      "Number of iterations in a TPU training loop.")
-# Fathom
-flags.DEFINE_integer("mock_max_docs", None, "Mocked max number of docs.")
-flags.DEFINE_integer("mock_chunks_per_doc", None, "Mocked number of chunks per "
-                                                  "doc.")
-flags.DEFINE_integer("mock_chunk_length", None, "Mocked chunk size.")
 flags.DEFINE_bool("use_tpu", False, "Whether to use TPU.")
 flags.DEFINE_bool("use_tpu_estimator", False, "Whether to use TPUEstimator. "
                   "This is always enabled when use_tpu is True.")
@@ -190,6 +185,8 @@ def create_hparams():
   hparams = trainer_lib.create_hparams(FLAGS.hparams_set, FLAGS.hparams)
 
   # Fathom
+  PackedMocker.setup_mock_flags()
+
   if PackedMocker.verify_mock_flags(
           [FLAGS.mock_max_docs,
            FLAGS.mock_chunks_per_doc,

--- a/tensor2tensor/bin/t2t_trainer.py
+++ b/tensor2tensor/bin/t2t_trainer.py
@@ -398,8 +398,11 @@ def main(argv):
     
   # Fathom
   if FLAGS.mock_max_docs and FLAGS.mock_chunks_per_doc and FLAGS.mock_chunk_length:
-    tf.logging.info('Found mocking flags, proceeding to mock hparams as '
-                    'specified.')
+    tf.logging.info(f'Found mocking flags, proceeding to mock hparams as '
+                    f'specified. Mocked values: '
+                    f'max_docs = {FLAGS.mock_max_docs}, '
+                    f'chunks_per_doc = {FLAGS.mock_chunks_per_doc}, '
+                    f'chunk_length = {FLAGS.mock_chunk_length}')
     hparams = PackedMocker.generate_model_hparams(
       max_docs=FLAGS.mock_max_docs,
       chunks_per_doc=FLAGS.mock_chunks_per_doc,

--- a/tensor2tensor/bin/t2t_trainer.py
+++ b/tensor2tensor/bin/t2t_trainer.py
@@ -397,9 +397,9 @@ def main(argv):
   #   FLAGS.output_dir = cloud_mlengine.job_dir()
     
   # Fathom
-  if all(FLAGS.mock_max_docs,
-         FLAGS.mock_chunks_per_doc,
-         FLAGS.mock_chunk_length):
+  if all([FLAGS.mock_max_docs,
+          FLAGS.mock_chunks_per_doc,
+          FLAGS.mock_chunk_length]):
     hparams = PackedMocker.generate_model_hparams(
       max_docs=FLAGS.mock_max_docs,
       chunks_per_doc=FLAGS.mock_chunks_per_doc,

--- a/tensor2tensor/bin/t2t_trainer.py
+++ b/tensor2tensor/bin/t2t_trainer.py
@@ -35,6 +35,7 @@ import tensorflow as tf
 
 # Fathom
 import fathomt2t_dependencies.t2t_trainer_utils as fathom
+from fathomt2t.problems.packed_mocker import PackedMocker
 
 from tensorflow.contrib.tpu.python.tpu import tpu_config
 
@@ -52,6 +53,11 @@ flags.DEFINE_integer("random_seed", None, "Random seed.")
 flags.DEFINE_integer("tpu_num_shards", 8, "Number of tpu shards.")
 flags.DEFINE_integer("iterations_per_loop", 100,
                      "Number of iterations in a TPU training loop.")
+# Fathom
+flags.DEFINE_integer("mock_max_docs", None, "Mocked max number of docs.")
+flags.DEFINE_integer("mock_chunks_per_doc", None, "Mocked number of chunks per "
+                                                  "doc.")
+flags.DEFINE_integer("mock_chunk_length", None, "Mocked chunk size.")
 flags.DEFINE_bool("use_tpu", False, "Whether to use TPU.")
 flags.DEFINE_bool("use_tpu_estimator", False, "Whether to use TPUEstimator. "
                   "This is always enabled when use_tpu is True.")
@@ -388,9 +394,16 @@ def main(argv):
   # if cloud_mlengine.job_dir():
   #   FLAGS.output_dir = cloud_mlengine.job_dir()
     
-  if argv:
-    set_hparams_from_args(argv[1:])
-  hparams = create_hparams()
+  # Fathom
+  if FLAGS.mock_max_docs and FLAGS.mock_chunks_per_doc and FLAGS.mock_chunk_length:
+    hparams = PackedMocker.generate_model_hparams(
+      max_docs=FLAGS.mock_max_docs,
+      chunks_per_doc=FLAGS.mock_chunks_per_doc,
+      chunk_length=FLAGS.mock_chunk_length)
+  else:
+    if argv:
+      set_hparams_from_args(argv[1:])
+    hparams = create_hparams()
 
   # Fathom
   hparams = fathom.adjust_params_for_scaling(hparams)

--- a/tensor2tensor/bin/t2t_trainer.py
+++ b/tensor2tensor/bin/t2t_trainer.py
@@ -184,7 +184,7 @@ def create_hparams():
   hparams = trainer_lib.create_hparams(FLAGS.hparams_set, FLAGS.hparams)
 
   # Fathom: Verify mock flags have been specified and apply accordingly
-  hparams = modify_if_mocked(hparams)
+  hparams = modify_if_mocked(FLAGS, hparams)
   return hparams
 
 

--- a/tensor2tensor/bin/t2t_trainer.py
+++ b/tensor2tensor/bin/t2t_trainer.py
@@ -36,7 +36,6 @@ import tensorflow as tf
 # Fathom
 import fathomt2t_dependencies.t2t_trainer_utils as fathom
 from fathomt2t.problems.packed_mocker import PackedMocker
-from fathomt2t.models.fh_transformer import fh_transformer_packed
 
 from tensorflow.contrib.tpu.python.tpu import tpu_config
 

--- a/tensor2tensor/bin/t2t_trainer.py
+++ b/tensor2tensor/bin/t2t_trainer.py
@@ -35,6 +35,7 @@ import tensorflow as tf
 
 # Fathom
 import fathomt2t_dependencies.t2t_trainer_utils as fathom
+from fathomt2t.problems.packed_mocker import modify_if_mocked
 
 from tensorflow.contrib.tpu.python.tpu import tpu_config
 

--- a/tensor2tensor/bin/t2t_trainer.py
+++ b/tensor2tensor/bin/t2t_trainer.py
@@ -191,10 +191,10 @@ def create_hparams():
   hparams = trainer_lib.create_hparams(FLAGS.hparams_set, FLAGS.hparams)
 
   # Fathom
-  mocked_flags = [
-      FLAGS.mock_max_docs, FLAGS.mock_chunks_per_doc, FLAGS.mock_chunk_length]
-  if any(mocked_flags):
-    assert all(mocked_flags), "Some but not all mock flags were specified."
+  if PackedMocker.verify_mock_flags(
+          [FLAGS.mock_max_docs,
+           FLAGS.mock_chunks_per_doc,
+           FLAGS.mock_chunk_length]):
     hparams = PackedMocker.generate_model_hparams(
       max_docs=FLAGS.mock_max_docs,
       chunks_per_doc=FLAGS.mock_chunks_per_doc,

--- a/tensor2tensor/bin/t2t_trainer.py
+++ b/tensor2tensor/bin/t2t_trainer.py
@@ -183,7 +183,8 @@ def create_hparams():
                     "e.g. transformer_tpu, if available for your model.")
   hparams = trainer_lib.create_hparams(FLAGS.hparams_set, FLAGS.hparams)
 
-  # Fathom
+  # Fathom: Verify mock flags have been specified and apply accordingly, see
+  # fathomt2t/problems/packed_mocker.py for details
   if PackedMocker.verify_mock_flags(
           [FLAGS.mock_max_docs,
            FLAGS.mock_chunks_per_doc,

--- a/tensor2tensor/bin/t2t_trainer.py
+++ b/tensor2tensor/bin/t2t_trainer.py
@@ -38,7 +38,6 @@ import fathomt2t_dependencies.t2t_trainer_utils as fathom
 from fathomt2t.problems.packed_mocker import PackedMocker
 from fathomt2t.models.fh_transformer import fh_transformer_packed
 
-
 from tensorflow.contrib.tpu.python.tpu import tpu_config
 
 flags = tf.flags

--- a/tensor2tensor/bin/t2t_trainer.py
+++ b/tensor2tensor/bin/t2t_trainer.py
@@ -185,8 +185,6 @@ def create_hparams():
   hparams = trainer_lib.create_hparams(FLAGS.hparams_set, FLAGS.hparams)
 
   # Fathom
-  PackedMocker.setup_mock_flags()
-
   if PackedMocker.verify_mock_flags(
           [FLAGS.mock_max_docs,
            FLAGS.mock_chunks_per_doc,

--- a/tensor2tensor/bin/t2t_trainer.py
+++ b/tensor2tensor/bin/t2t_trainer.py
@@ -35,7 +35,7 @@ import tensorflow as tf
 
 # Fathom
 import fathomt2t_dependencies.t2t_trainer_utils as fathom
-from fathomt2t.problems.packed_mocker import PackedMocker
+import fathomt2t.problems.packed_mocker as packed_mocker
 
 from tensorflow.contrib.tpu.python.tpu import tpu_config
 
@@ -183,13 +183,9 @@ def create_hparams():
                     "e.g. transformer_tpu, if available for your model.")
   hparams = trainer_lib.create_hparams(FLAGS.hparams_set, FLAGS.hparams)
 
-  # Fathom: Verify mock flags have been specified and apply accordingly, see
-  # fathomt2t/problems/packed_mocker.py for details
-  if PackedMocker.verify_mock_flags(
-          [FLAGS.mock_max_docs,
-           FLAGS.mock_chunks_per_doc,
-           FLAGS.mock_chunk_length]):
-    hparams = PackedMocker.generate_model_hparams(
+  # Fathom: Verify mock flags have been specified and apply accordingly
+  if packed_mocker.verify_mock_flags():
+    hparams = packed_mocker.generate_model_hparams(
       max_docs=FLAGS.mock_max_docs,
       chunks_per_doc=FLAGS.mock_chunks_per_doc,
       chunk_length=FLAGS.mock_chunk_length,

--- a/tensor2tensor/bin/t2t_trainer.py
+++ b/tensor2tensor/bin/t2t_trainer.py
@@ -35,7 +35,7 @@ import tensorflow as tf
 
 # Fathom
 import fathomt2t_dependencies.t2t_trainer_utils as fathom
-import fathomt2t.problems.packed_mocker as packed_mocker
+from fathomt2t.problems.packed_mocker import modify_if_mocked
 
 from tensorflow.contrib.tpu.python.tpu import tpu_config
 
@@ -184,12 +184,7 @@ def create_hparams():
   hparams = trainer_lib.create_hparams(FLAGS.hparams_set, FLAGS.hparams)
 
   # Fathom: Verify mock flags have been specified and apply accordingly
-  if packed_mocker.verify_mock_flags():
-    hparams = packed_mocker.generate_model_hparams(
-      max_docs=FLAGS.mock_max_docs,
-      chunks_per_doc=FLAGS.mock_chunks_per_doc,
-      chunk_length=FLAGS.mock_chunk_length,
-      base_hparams=hparams)
+  hparams = modify_if_mocked(hparams)
   return hparams
 
 

--- a/tensor2tensor/bin/t2t_trainer.py
+++ b/tensor2tensor/bin/t2t_trainer.py
@@ -36,6 +36,8 @@ import tensorflow as tf
 # Fathom
 import fathomt2t_dependencies.t2t_trainer_utils as fathom
 from fathomt2t.problems.packed_mocker import PackedMocker
+from fathomt2t.models.fh_transformer import fh_transformer_packed
+
 
 from tensorflow.contrib.tpu.python.tpu import tpu_config
 
@@ -399,7 +401,8 @@ def main(argv):
     hparams = PackedMocker.generate_model_hparams(
       max_docs=FLAGS.mock_max_docs,
       chunks_per_doc=FLAGS.mock_chunks_per_doc,
-      chunk_length=FLAGS.mock_chunk_length)
+      chunk_length=FLAGS.mock_chunk_length,
+      base_hparams=fh_transformer_packed)
   else:
     if argv:
       set_hparams_from_args(argv[1:])

--- a/tensor2tensor/bin/t2t_trainer.py
+++ b/tensor2tensor/bin/t2t_trainer.py
@@ -202,7 +202,6 @@ def create_hparams():
   return hparams
 
 
-
 def create_experiment_fn():
   return trainer_lib.create_experiment_fn(
       model_name=FLAGS.model,

--- a/tensor2tensor/bin/t2t_trainer.py
+++ b/tensor2tensor/bin/t2t_trainer.py
@@ -398,6 +398,8 @@ def main(argv):
     
   # Fathom
   if FLAGS.mock_max_docs and FLAGS.mock_chunks_per_doc and FLAGS.mock_chunk_length:
+    tf.logging.info('Found mocking flags, proceeding to mock hparams as '
+                    'specified.')
     hparams = PackedMocker.generate_model_hparams(
       max_docs=FLAGS.mock_max_docs,
       chunks_per_doc=FLAGS.mock_chunks_per_doc,

--- a/tensor2tensor/bin/t2t_trainer.py
+++ b/tensor2tensor/bin/t2t_trainer.py
@@ -397,12 +397,9 @@ def main(argv):
   #   FLAGS.output_dir = cloud_mlengine.job_dir()
     
   # Fathom
-  if FLAGS.mock_max_docs and FLAGS.mock_chunks_per_doc and FLAGS.mock_chunk_length:
-    tf.logging.info(f'Found mocking flags, proceeding to mock hparams as '
-                    f'specified. Mocked values: '
-                    f'max_docs = {FLAGS.mock_max_docs}, '
-                    f'chunks_per_doc = {FLAGS.mock_chunks_per_doc}, '
-                    f'chunk_length = {FLAGS.mock_chunk_length}')
+  if all(FLAGS.mock_max_docs,
+         FLAGS.mock_chunks_per_doc,
+         FLAGS.mock_chunk_length):
     hparams = PackedMocker.generate_model_hparams(
       max_docs=FLAGS.mock_max_docs,
       chunks_per_doc=FLAGS.mock_chunks_per_doc,

--- a/tensor2tensor/bin/t2t_trainer.py
+++ b/tensor2tensor/bin/t2t_trainer.py
@@ -180,15 +180,11 @@ def create_hparams():
     tf.logging.warn("Not all hyperparameter sets work on TPU. "
                     "Prefer hparams_sets with a '_tpu' suffix, "
                     "e.g. transformer_tpu, if available for your model.")
-<<<<<<< HEAD
   hparams = trainer_lib.create_hparams(FLAGS.hparams_set, FLAGS.hparams)
 
   # Fathom: Verify mock flags have been specified and apply accordingly
   hparams = modify_if_mocked(FLAGS, hparams)
   return hparams
-=======
-  return trainer_lib.create_hparams(FLAGS.hparams_set, FLAGS.hparams)
->>>>>>> cb28720c2a971a2f7f587b75e00e8fd6ef8ba3c5
 
 
 def create_experiment_fn():

--- a/tensor2tensor/bin/t2t_trainer.py
+++ b/tensor2tensor/bin/t2t_trainer.py
@@ -35,7 +35,6 @@ import tensorflow as tf
 
 # Fathom
 import fathomt2t_dependencies.t2t_trainer_utils as fathom
-from fathomt2t.problems.packed_mocker import modify_if_mocked
 
 from tensorflow.contrib.tpu.python.tpu import tpu_config
 
@@ -181,11 +180,7 @@ def create_hparams():
     tf.logging.warn("Not all hyperparameter sets work on TPU. "
                     "Prefer hparams_sets with a '_tpu' suffix, "
                     "e.g. transformer_tpu, if available for your model.")
-  hparams = trainer_lib.create_hparams(FLAGS.hparams_set, FLAGS.hparams)
-
-  # Fathom: Verify mock flags have been specified and apply accordingly
-  hparams = modify_if_mocked(FLAGS, hparams)
-  return hparams
+  return trainer_lib.create_hparams(FLAGS.hparams_set, FLAGS.hparams)
 
 
 def create_experiment_fn():

--- a/tensor2tensor/bin/t2t_trainer.py
+++ b/tensor2tensor/bin/t2t_trainer.py
@@ -191,9 +191,10 @@ def create_hparams():
   hparams = trainer_lib.create_hparams(FLAGS.hparams_set, FLAGS.hparams)
 
   # Fathom
-  if all([FLAGS.mock_max_docs,
-          FLAGS.mock_chunks_per_doc,
-          FLAGS.mock_chunk_length]):
+  mocked_flags = [
+      FLAGS.mock_max_docs, FLAGS.mock_chunks_per_doc, FLAGS.mock_chunk_length]
+  if any(mocked_flags):
+    assert all(mocked_flags), "Some but not all mock flags were specified."
     hparams = PackedMocker.generate_model_hparams(
       max_docs=FLAGS.mock_max_docs,
       chunks_per_doc=FLAGS.mock_chunks_per_doc,
@@ -409,7 +410,7 @@ def main(argv):
   #   FLAGS.output_dir = cloud_mlengine.job_dir()
 
   if argv:
-      set_hparams_from_args(argv[1:])
+    set_hparams_from_args(argv[1:])
   hparams = create_hparams()
 
   # Fathom

--- a/tensor2tensor/data_generators/problem.py
+++ b/tensor2tensor/data_generators/problem.py
@@ -1157,7 +1157,6 @@ class Problem(object):
     # Fathom
     # override shapes for packed datsets that will be chunked
     override_shapes_for_packed(self, hparams, padded_shapes, max_length)
-
     return padded_shapes
 
 

--- a/tensor2tensor/data_generators/problem.py
+++ b/tensor2tensor/data_generators/problem.py
@@ -39,7 +39,7 @@ import tensorflow as tf
 from tensorflow.contrib.tpu.python.tpu import tpu_config
 
 import pretrained_models.bert.utilities as bert_utilities
-from fathomt2t_dependencies.common_t2t_utils import prepare_for_chunking
+from fathomt2t_dependencies.common_t2t_utils import maybe_prepare_for_chunking
 
 
 class DatasetSplit(object):

--- a/tensor2tensor/data_generators/problem.py
+++ b/tensor2tensor/data_generators/problem.py
@@ -1000,7 +1000,7 @@ class Problem(object):
     else:
 
       # if dataset is packed (TPU requires packed dataset)
-      self.apply_batch_settings(dataset=dataset, hparams=hparams,
+      dataset = self.apply_batch_settings(dataset=dataset, hparams=hparams,
                                 num_shards=num_shards, num_threads=num_threads,
                                 is_training=is_training, params=params,
                                 config=config)

--- a/tensor2tensor/data_generators/problem.py
+++ b/tensor2tensor/data_generators/problem.py
@@ -844,7 +844,7 @@ class Problem(object):
 
   # Fathom
   def apply_batch_settings(self, dataset, hparams, num_shards, num_threads,
-                           is_training, **kwargs):
+                           config, is_training, **kwargs):
     """Buckets dataset by length.
 
     Filters dataset according to valid gpu sizes, batches, and applies bucketing

--- a/tensor2tensor/data_generators/problem.py
+++ b/tensor2tensor/data_generators/problem.py
@@ -883,8 +883,7 @@ class Problem(object):
                           "data_parallelism") and config.data_parallelism:
       num_shards = config.data_parallelism.n
     else:
-      pass
-    num_shards = 4
+      num_shards = 1
 
     max_length = self.max_length(hparams)
 

--- a/tensor2tensor/data_generators/problem.py
+++ b/tensor2tensor/data_generators/problem.py
@@ -883,7 +883,8 @@ class Problem(object):
                           "data_parallelism") and config.data_parallelism:
       num_shards = config.data_parallelism.n
     else:
-      num_shards = 1
+      pass
+    num_shards = 4
 
     max_length = self.max_length(hparams)
 
@@ -1158,7 +1159,9 @@ class Problem(object):
     # override shapes for packed datsets that will be chunked
     packed_length = getattr(self, 'packed_length', False)
     if packed_length:
-      assert packed_length == max_length
+      assert packed_length == max_length, (f'Problem packed len '
+                                           f'{packed_length} != the model '
+                                           f'hparam max length {max_length}')
 
       # TODO: rename inputs_chunk_mask as it behaves differently
       # from other inputs_*


### PR DESCRIPTION
ASANA TASK LINK:
https://app.asana.com/0/1137246510213018/1150304419693266/f

DESIGN DOC LINK:
https://docs.google.com/document/u/1/d/14utI7zwOmaYldHs7nzw_J24Rspu-DclbhahpfuFxj4g/edit#

DETAILS
We want tools to mock hparam values, copy them into the problem, and also generate fake padded data. See https://github.com/medicode/diseaseTools/pull/5176 for reference. Here we ensure that hparam mocking flags are appropriately caught, verified, and fed into PackedMocker accordingly.

Note: This is a PR addressing the fixes outlined here (https://github.com/medicode/tensor2tensor/pull/148) with a different branch name to allow circleCI to build with the associated branch from diseaseTools.