### PR TITLE
Fix tensor2tensor ci's trigger smoke test step.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -77,7 +77,7 @@ jobs:
       - type: shell
         name: Trigger smoke tests
         # CI sets up the root directory to project, which is here the tensor2tensor repo
-        command: python ./fathomairflow/integration_tests/trigger_tests_on_testinfra.py trigger_smoke_tests ~/project
+        command: docker run -it -e 'GOOGLE_APPLICATION_CREDENTIALS=/usr/src/app/gcloud/keys/google-auth.json' -v ~/gdm:/usr/src/app/gcloud/gdm -v ~/diseaseTools:/usr/src/app -v ~/project:/usr/src/project -w /usr/src/project gcr.io/fathom-containers/ci python /usr/src/app/fathomairflow/integration_tests/trigger_tests_on_testinfra.py queue_smoke_tests /usr/src/project
         workDir: ~/diseaseTools
 workflows:
   version: 2


### PR DESCRIPTION
<PR title>

**ASANA TASK LINK:**
https://app.asana.com/0/1142555270241225/1154356479706209/f

**DESIGN DOC LINK:**
N/A

DETAILS
-------
Fixing smoke test issues by running it within our gcr.io/fathom-containers/ci container. Additionally, 
we've since added a firewall in front of our cluster resulting in a change in this setup. CI doesn't have access to our cluster since we don't know the machine's IP address and thus can't add it to the cluster's firewall whitelist. Instead, CI is expected to publish tests to a topic which triggers a deployment in our cluster that's set up to runs the tests and foward alerts as needed.

CHECK LIST
----------

**Sufficient logging?**

  - [ ] I, the reviewer, thought about logging in all possible instances
  - [x] I, the coder, added logging in all possible instances

**Good to merge if approved?**

- [ ] yes, the reviewer should merge if he/she can upon approval

**TEST PLAN:**
- [x] Manually ran CI.

**DID I MATERIALLY UPDATE DOCKERFILE(S)?:**
N

**ANY KNOWN IMPACT TO CUSTOMER SLAs?:**
N

**RISK & IMPACT ASSESSMENT:**
Minimal