### PR TITLE
Update to TensorFlow 1.15.2

### DIFF
--- a/tensor2tensor/models/__init__.py
+++ b/tensor2tensor/models/__init__.py
@@ -69,7 +69,6 @@ from tensor2tensor.models.video import basic_recurrent
 from tensor2tensor.models.video import basic_stochastic
 from tensor2tensor.models.video import emily
 from tensor2tensor.models.video import epva
-# from tensor2tensor.models.video import savp
 from tensor2tensor.models.video import sv2p
 
 from tensor2tensor.utils import registry

--- a/tensor2tensor/models/__init__.py
+++ b/tensor2tensor/models/__init__.py
@@ -69,7 +69,7 @@ from tensor2tensor.models.video import basic_recurrent
 from tensor2tensor.models.video import basic_stochastic
 from tensor2tensor.models.video import emily
 from tensor2tensor.models.video import epva
-from tensor2tensor.models.video import savp
+# from tensor2tensor.models.video import savp
 from tensor2tensor.models.video import sv2p
 
 from tensor2tensor.utils import registry

--- a/tensor2tensor/models/__init__.py
+++ b/tensor2tensor/models/__init__.py
@@ -69,6 +69,11 @@ from tensor2tensor.models.video import basic_recurrent
 from tensor2tensor.models.video import basic_stochastic
 from tensor2tensor.models.video import emily
 from tensor2tensor.models.video import epva
+# Fathom BEGIN
+# removed because gan packages were split off into tensorflow-gan
+# rather than supporting gans, we simply do not import gan models
+# from tensor2tensor.models.video import savp
+# Fathom END
 from tensor2tensor.models.video import sv2p
 
 from tensor2tensor.utils import registry


### PR DESCRIPTION
1. Paired with an update to tensorflow from 1.14 to 1.15.2
2. This PR should be merged in before [this](https://github.com/medicode/diseaseTools/pull/6069) PR.
3. We observed an incompatibility with GANs (1.15.2 pulls out gan support as a separate package `tensorflow-gan`), and we opted to simply not import any models relying on this package.

https://app.asana.com/0/1137246510213018/1161531535701217/f