### PR TITLE
Rename inputs_chunk_mask

### DIFF
--- a/tensor2tensor/data_generators/problem.py
+++ b/tensor2tensor/data_generators/problem.py
@@ -1164,7 +1164,7 @@ class Problem(object):
     of chunk length
 
     features:
-        inputs_chunk_mask [num_chunks * max_docs_per_pack]
+        chunk_mask [num_chunks * max_docs_per_pack]
         inputs_* [packed_length]
 
     """


### PR DESCRIPTION
We make reference to inputs_chunk_mask, this is a more verbose name than necessary. Truly this is just a chunk_mask and we should consistently refer to it as that.

- Associated changes in diseaseTools here https://github.com/medicode/diseaseTools/pull/6109
- Asana task: https://app.asana.com/0/1137246510213018/1143626077249181/f
- Testing: This is a comment so none needed
- Divergence from Tensor2Tensor: Minimal, this is in our own function