### PR TITLE
Remove packed prediction + modify packed problem logic

### DIFF
--- a/tensor2tensor/bin/t2t_decoder.py
+++ b/tensor2tensor/bin/t2t_decoder.py
@@ -126,6 +126,8 @@ def decode(estimator, hparams, decode_hp):
         # in situations where we are calling decode without write permissions
         # to the model directory
         output_dir=os.path.splitext(FLAGS.decode_output_file)[0])
+    print("Pred")
+    print(predictions)
 
     # Fathom
     if FLAGS.fathom_output_predictions:

--- a/tensor2tensor/bin/t2t_decoder.py
+++ b/tensor2tensor/bin/t2t_decoder.py
@@ -126,8 +126,6 @@ def decode(estimator, hparams, decode_hp):
         # in situations where we are calling decode without write permissions
         # to the model directory
         output_dir=os.path.splitext(FLAGS.decode_output_file)[0])
-    print("Pred")
-    print(predictions)
 
     # Fathom
     if FLAGS.fathom_output_predictions:

--- a/tensor2tensor/utils/decoding.py
+++ b/tensor2tensor/utils/decoding.py
@@ -29,6 +29,8 @@ import six
 
 from six.moves import input  # pylint: disable=redefined-builtin
 
+from fathomt2t.models.fh_transformer import is_hparams_packed
+
 from tensor2tensor.data_generators import problem as problem_lib
 from tensor2tensor.data_generators import text_encoder
 from tensor2tensor.data_generators import text_problems
@@ -143,18 +145,6 @@ def log_decode_results(inputs,
   return decoded_inputs, decoded_outputs, decoded_targets
 
 
-##############
-# BEGIN FATHOM
-##############
-
-def is_packed(hparams):
-  return hasattr(hparams, "packed_length")
-
-##############
-# END FATHOM
-##############
-
-
 def decode_from_dataset(estimator,
                         problem_name,
                         hparams,
@@ -221,8 +211,9 @@ def decode_from_dataset(estimator,
   # to yield multiple examples
 
   # Get the predictions as an iterable
-  predictions = estimator.predict(infer_input_fn,
-                                  yield_single_examples=not is_packed(hparams))
+  predictions = estimator.predict(
+      infer_input_fn,
+      yield_single_examples=not is_hparams_packed(hparams))
 
   # Just return the generator directly if requested
   if return_generator:

--- a/tensor2tensor/utils/decoding.py
+++ b/tensor2tensor/utils/decoding.py
@@ -222,7 +222,7 @@ def decode_from_dataset(estimator,
 
   # Get the predictions as an iterable
   predictions = estimator.predict(infer_input_fn,
-                                  yield_single_examples=is_packed(hparams))
+                                  yield_single_examples=not is_packed(hparams))
 
   # Just return the generator directly if requested
   if return_generator:

--- a/tensor2tensor/utils/decoding.py
+++ b/tensor2tensor/utils/decoding.py
@@ -29,7 +29,7 @@ import six
 
 from six.moves import input  # pylint: disable=redefined-builtin
 
-from fathomt2t_dependencies.t2t_trainer_utils import is_hparams_packed
+from fathomt2t_dependencies.hparam_utils import is_hparams_packed
 
 from tensor2tensor.data_generators import problem as problem_lib
 from tensor2tensor.data_generators import text_encoder

--- a/tensor2tensor/utils/decoding.py
+++ b/tensor2tensor/utils/decoding.py
@@ -34,10 +34,6 @@ from tensor2tensor.data_generators import text_encoder
 from tensor2tensor.data_generators import text_problems
 from tensor2tensor.utils import registry
 
-# Note: The PACKED_TO_PREDICTION_PROBLEM dict should not be in the
-#  dag_management code, and should instead be fathomt2t/problems/
-# Once dag code is allowed to import non-dag code again, please move this dict
-from fathomairflow.dags.dag_management.common import PACKED_TO_PREDICTION_PROBLEM
 import tensorflow as tf
 
 FLAGS = tf.flags.FLAGS
@@ -206,16 +202,8 @@ def decode_from_dataset(estimator,
   # BEGIN FATHOM
   ##############
 
-  # When our problems are packed, a single example corresponds to multiple docs
-  # As a consequence, when we feed a single example into our model, it will
-  # return multiple logits. When estimator sees a discrepancy between examples
-  # coming in and predictions going out, it will throw an error unless told
-  # to yield multiple examples
-  packed_problem = problem_name in PACKED_TO_PREDICTION_PROBLEM.values()
-
   # Get the predictions as an iterable
-  predictions = estimator.predict(
-      infer_input_fn, yield_single_examples=not packed_problem)
+  predictions = estimator.predict(infer_input_fn)
 
   # Just return the generator directly if requested
   if return_generator:

--- a/tensor2tensor/utils/decoding.py
+++ b/tensor2tensor/utils/decoding.py
@@ -29,7 +29,7 @@ import six
 
 from six.moves import input  # pylint: disable=redefined-builtin
 
-from fathomt2t.models.fh_transformer import is_hparams_packed
+from fathomt2t_dependencies.t2t_trainer_utils import is_hparams_packed
 
 from tensor2tensor.data_generators import problem as problem_lib
 from tensor2tensor.data_generators import text_encoder

--- a/tensor2tensor/utils/decoding.py
+++ b/tensor2tensor/utils/decoding.py
@@ -143,6 +143,18 @@ def log_decode_results(inputs,
   return decoded_inputs, decoded_outputs, decoded_targets
 
 
+##############
+# BEGIN FATHOM
+##############
+
+def is_packed(hparams):
+  return hasattr(hparams, "packed_length")
+
+##############
+# END FATHOM
+##############
+
+
 def decode_from_dataset(estimator,
                         problem_name,
                         hparams,
@@ -202,8 +214,15 @@ def decode_from_dataset(estimator,
   # BEGIN FATHOM
   ##############
 
+  # When our problems are packed, a single example corresponds to multiple docs
+  # As a consequence, when we feed a single example into our model, it will
+  # return multiple logits. When estimator sees a discrepancy between examples
+  # coming in and predictions going out, it will throw an error unless told
+  # to yield multiple examples
+
   # Get the predictions as an iterable
-  predictions = estimator.predict(infer_input_fn, yield_single_examples=False)
+  predictions = estimator.predict(infer_input_fn,
+                                  yield_single_examples=is_packed(hparams))
 
   # Just return the generator directly if requested
   if return_generator:

--- a/tensor2tensor/utils/decoding.py
+++ b/tensor2tensor/utils/decoding.py
@@ -203,7 +203,7 @@ def decode_from_dataset(estimator,
   ##############
 
   # Get the predictions as an iterable
-  predictions = estimator.predict(infer_input_fn)
+  predictions = estimator.predict(infer_input_fn, yield_single_examples=False)
 
   # Just return the generator directly if requested
   if return_generator:


### PR DESCRIPTION
Asana task: https://app.asana.com/0/1137246510213018/1163154464222281/f
Design Doc: https://docs.google.com/document/d/1qNCauZ8syxS9-_5I6xS-u7T8gUeT0OBFg3JV9mjbk60/edit#heading=h.tvwinx3uhzxx

The system has been updated to work for both packed and unpacked problems, without any need for a packed prediction problem.

For packed prediction problems, we get all documents in 1 batch in at a time and as 1 example.  So we do not want tf to try to split these up.

diseaseTools PR: medicode/diseaseTools#6123