### PR TITLE
Fix return typing of tpu_batch_size_per_shard

### DIFF
--- a/tensor2tensor/data_generators/problem.py
+++ b/tensor2tensor/data_generators/problem.py
@@ -299,7 +299,7 @@ class Problem(object):
       an integer
     """
     if self.batch_size_means_tokens and not model_hparams.use_fixed_batch_size:
-      return model_hparams.batch_size // self.max_length(model_hparams)
+      return int(model_hparams.batch_size / self.max_length(model_hparams))
     else:
       return model_hparams.batch_size
 


### PR DESCRIPTION
**BEST PRACTICES:**

  - [x] I did my best to follow [Fathom PR Best Practices](https://docs.google.com/document/d/1d7FBIRyDmgTvlpBBBdYtiP1IOm0s5cvP0Sae3l2dMzU/edit)
  - [x] I did my best to follow [Fathom Style Guide & Best Design Practices](https://docs.google.com/document/d/15Bc31w96t-KudUw_qw6zsiabFpEDVAXTtXNdD3PR0_g/edit#heading=h.lica5qr8yb37)
  - [ ] If I led the design, I did my best to follow [Fathom Design Document Design Practices](https://docs.google.com/document/d/11xgD11LRRsF5hPzmyvZIxymk4HbfNVs3-ckxw_DeMuw/edit#)
  - [ ] If I *didn't* lead the design, I think the associated design document *does* follow Fathom Design Document Design Practices.  (Why? If you don't, then there is a good chance that the wrong thing might be coded up.)

**ASANA TASK LINK:** https://app.asana.com/0/1165666428840050/1167211864330901/f

**DESIGN DOC LINK:** None

DETAILS
-------
The tpu_batch_size_per_shard function in problem.py should return an int, but sometimes returns a float.

CHECK LIST
----------

**Sufficient logging?**

Refer to [When should I log?](https://docs.google.com/document/d/1lNph_Yea5XUMyFbCZK9XPh3Sn_1aaw4_8DWCkAZYENo/edit#heading=h.n40pw382u0yi)

  - [ ] I, the reviewer, thought about logging in all possible instances
  - [x] I, the coder, added logging in all possible instances

**Good to merge if approved?**

- [x] yes, the reviewer should merge if he/she can upon approval

**TEST PLAN:** Ran DAG

- [ ] Best: "New tests covering XYZ cases"
- [x] Sometimes: "Run dag and manually verify blah", etc.
- [ ] Occasionally: "Best guess is this fixes the issue." <-- at least be honest!

**DID I MATERIALLY UPDATE DOCKERFILE(S)?:** N

**ANY KNOWN IMPACT TO 3rd PARTY (CUSTOMERS, VENDORS, PARTNERS, etc.) integrations or SLAs?:** N

**RISK & IMPACT ASSESSMENT:** Minimal
