### PR TITLE
CircleCI key rotation: 2020-04-08 (2)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ jobs:
       - type: shell
         name: Setup Google Cloud Credentials
         workDir: ~/
-        command: &GCP_LOGIN mkdir -p ~/diseaseTools/gcloud/keys && echo $CIRCLECI_GCP_SA_KEY_2020_04_08 | base64 --decode --ignore-garbage > ~/diseaseTools/gcloud/keys/google-auth.json
+        command: &GCP_LOGIN mkdir -p ~/diseaseTools/gcloud/keys && echo $CIRCLECI_GCP_SA_KEY_2020_04_08_2 | base64 --decode --ignore-garbage > ~/diseaseTools/gcloud/keys/google-auth.json
 
       - type: shell
         name: Docker login


### PR DESCRIPTION
**ASANA TASK LINK:**
[Set up medicode/k8s CI env var via key rotation](https://app.asana.com/0/0/1170543543190602/f)

**DESIGN DOC LINK:**
[Rotate CircleCI GCP Service Account Keys Playbook](https://docs.google.com/document/d/1S7qo2jRIeMdmovHZ6R91dytITUi8tfa1QRvKYa7y18U/edit#)

DETAILS
-------
 Second key rotation on 2020-04-08 to provide CircleCI an SA key on new k8s repository