### PR TITLE
Remove branch matching

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,14 +11,6 @@ jobs:
         command: |
           DT_BRANCH='develop';
           GDM_BRANCH='develop';
-          if [[ ${CIRCLE_BRANCH} != 'master' ]]; then
-            if [[ $(git ls-remote --heads git@github.com:medicode/diseaseTools.git -b ${CIRCLE_BRANCH}) ]]; then
-              DT_BRANCH=${CIRCLE_BRANCH};
-            fi;
-            if [[ $(git ls-remote --heads git@github.com:medicode/gdm.git -b ${CIRCLE_BRANCH}) ]]; then
-              GDM_BRANCH=${CIRCLE_BRANCH};
-            fi;
-          fi;
           git clone -b ${DT_BRANCH} git@github.com:medicode/diseaseTools.git ~/diseaseTools;
           git clone -b ${GDM_BRANCH} git@github.com:medicode/gdm.git ~/gdm;
 


### PR DESCRIPTION
**ASANA TASK LINK:**
https://app.asana.com/0/1199164230411419/1199677761601649


DETAILS
-------
We have functionality in .circleci/config that finds branches in other repo with same names, and uses them instead of develop. 

This function caused errors when we try to make a new branch but the branch name matches another old branch in other repo with the same name.

CHECK LIST
----------
**BEST PRACTICES:**

  - [x] I did my best to follow [Fathom PR Best Practices](https://docs.google.com/document/d/1d7FBIRyDmgTvlpBBBdYtiP1IOm0s5cvP0Sae3l2dMzU/edit)
  - [ ] I did my best to follow [Fathom Style Guide & Best Design Practices](https://docs.google.com/document/d/15Bc31w96t-KudUw_qw6zsiabFpEDVAXTtXNdD3PR0_g/edit#heading=h.lica5qr8yb37)
  - [ ] If I led the design, I did my best to follow [Fathom Design Document Design Practices](https://docs.google.com/document/d/11xgD11LRRsF5hPzmyvZIxymk4HbfNVs3-ckxw_DeMuw/edit#)
  - [ ] If I *didn't* lead the design, I think the associated design document *does* follow Fathom Design Document Design Practices.  (Why? If you don't, then there is a good chance that the wrong thing might be coded up.)

**SUFFICIENT LOGGING?**
Refer to [When should I log?](https://docs.google.com/document/d/1lNph_Yea5XUMyFbCZK9XPh3Sn_1aaw4_8DWCkAZYENo/edit#heading=h.n40pw382u0yi)

  - [ ] I, the reviewer, thought about logging in all possible instances
  - [ ] I, the coder, added logging in all possible instances

**GOOD TO MERGE IF APPROVED?**

- [x] yes, the reviewer should merge if he/she can upon approval

**TEST PLAN:**
You and your reviewer should have confidence that this PR (probably!) works as advertised.

- [ ] Best: "New tests covering XYZ cases"
- [ ] Sometimes: "Run dag and manually verify blah", etc.
- [x] Occasionally: "Best guess is this fixes the issue." <-- at least be honest!


**CHANGES TO DAG TOPOLOGY?**
N

*Before merging* I have:
- [ ] informed `@buildcop-lead` and `@datacop-lead` of the changes on [#eng-datacop](https://medicode.slack.com/archives/CTV6FGCG3), with a description of my changes and a link to this PR
- [ ] waited for `@datacop-lead`'s explicit approval to merge, in coordination with `@buildcop-lead`

**DID I MATERIALLY UPDATE DOCKERFILE(S)?:**
N

**ANY KNOWN IMPACT TO 3rd PARTY (CUSTOMERS, VENDORS, PARTNERS, etc.) integrations or SLAs?:**
N

**RISK & IMPACT ASSESSMENT:**
Minimal