### PR TITLE
Base LR schedule on global_step_offset_for_lr if present

### DIFF
--- a/tensor2tensor/utils/learning_rate.py
+++ b/tensor2tensor/utils/learning_rate.py
@@ -129,7 +129,7 @@ def _global_step(hparams):
     # raise AssertionError explicitly as `assert` statements are removed in
     # optimized byte code
     raise AssertionError(
-      f"global_step_offset_for_lr {step_offset} must be >= initial step {step}"
+      f"global_step_offset_for_lr {step_offset} must be <= initial step {step}"
     )
   step -= step_offset
 

--- a/tensor2tensor/utils/learning_rate.py
+++ b/tensor2tensor/utils/learning_rate.py
@@ -74,9 +74,18 @@ def learning_rate_factor(name, step_num, hparams):
     raise ValueError("unknown learning rate factor %s" % name)
 
 
+def _get_initial_step(hparams):
+  """Get initial step from haparams for finetune train"""
+  try:
+    return hparams.initial_step
+  except AttributeError:
+    return 0
+
+
 def learning_rate_schedule(hparams):
   """Learning rate schedule based on hparams."""
   step_num = _global_step(hparams)
+  step_num -= _get_initial_step(hparams)
   schedule_string = hparams.learning_rate_schedule
   names = schedule_string.split("*")
   names = [name.strip() for name in names if name.strip()]
@@ -89,6 +98,7 @@ def learning_rate_schedule(hparams):
 def legacy_learning_rate_schedule(hparams):
   """Backwards-compatible learning-rate schedule."""
   step_num = _global_step(hparams)
+  step_num -= _get_initial_step(hparams)
   warmup_steps = tf.to_float(hparams.learning_rate_warmup_steps)
   if hparams.learning_rate_decay_scheme == "noam":
     ret = 5000.0 * hparams.hidden_size**-0.5 * tf.minimum(

--- a/tensor2tensor/utils/learning_rate.py
+++ b/tensor2tensor/utils/learning_rate.py
@@ -74,15 +74,15 @@ def learning_rate_factor(name, step_num, hparams):
     raise ValueError("unknown learning rate factor %s" % name)
 
 
-def _get_initial_step(hparams):
+def _get_finetune_initial_step(hparams):
   """Get initial step from haparams for finetune train"""
-  return hparams.get("initial_step", 0)
+  return hparams.get("finetune_initial_step", 0)
 
 
 def learning_rate_schedule(hparams):
   """Learning rate schedule based on hparams."""
   step_num = _global_step(hparams)
-  step_num -= _get_initial_step(hparams)
+  step_num -= _get_finetune_initial_step(hparams)
   schedule_string = hparams.learning_rate_schedule
   names = schedule_string.split("*")
   names = [name.strip() for name in names if name.strip()]
@@ -95,7 +95,7 @@ def learning_rate_schedule(hparams):
 def legacy_learning_rate_schedule(hparams):
   """Backwards-compatible learning-rate schedule."""
   step_num = _global_step(hparams)
-  step_num -= _get_initial_step(hparams)
+  step_num -= _get_finetune_initial_step(hparams)
   warmup_steps = tf.to_float(hparams.learning_rate_warmup_steps)
   if hparams.learning_rate_decay_scheme == "noam":
     ret = 5000.0 * hparams.hidden_size**-0.5 * tf.minimum(

--- a/tensor2tensor/utils/learning_rate.py
+++ b/tensor2tensor/utils/learning_rate.py
@@ -84,7 +84,7 @@ def _get_global_step_offset_for_lr(hparams):
   but we want the LR scheduler to behave as if we are starting a new train with
   global_step = 0.
   """
-  return hparams.get("global_step_offset_for_lr", 0)
+  return tf.to_float(hparams.get("global_step_offset_for_lr", 0))
 
 
 def learning_rate_schedule(hparams):

--- a/tensor2tensor/utils/learning_rate.py
+++ b/tensor2tensor/utils/learning_rate.py
@@ -125,10 +125,12 @@ def _global_step(hparams):
   # _get_global_step_offset_for_lr defaults to 0 so this statement is a no-op
   # if the hparam is not set.
   step_offset = _get_global_step_offset_for_lr(hparams)
-  assert (
-    step_offset <= step,
-    f"global_step_offset_for_lr {step_offset} must be >= initial step {step}"
-  )
+  if step_offset > step:
+    # raise AssertionError explicitly as `assert` statements are removed in
+    # optimized byte code
+    raise AssertionError(
+      f"global_step_offset_for_lr {step_offset} must be >= initial step {step}"
+    )
   step -= step_offset
 
   multiplier = hparams.optimizer_multistep_accumulate_steps

--- a/tensor2tensor/utils/learning_rate.py
+++ b/tensor2tensor/utils/learning_rate.py
@@ -76,10 +76,7 @@ def learning_rate_factor(name, step_num, hparams):
 
 def _get_initial_step(hparams):
   """Get initial step from haparams for finetune train"""
-  try:
-    return hparams.initial_step
-  except AttributeError:
-    return 0
+  return hparams.get("initial_step", 0)
 
 
 def learning_rate_schedule(hparams):


### PR DESCRIPTION
https://app.asana.com/0/1200417715606741/1200486223471607/f

LR schedule is based on global step, but our finetune trains start at a non-zero global step (whatever the base model was trained to). This changes allows the LR schedule to look at a new `global_step_offset_for_lr` hparam when calculating LR schedule.