### PR TITLE
Change top() reshape to infer vocab size from the weights

### DIFF
--- a/tensor2tensor/layers/common_attention.py
+++ b/tensor2tensor/layers/common_attention.py
@@ -1,4 +1,4 @@
-# coding=utf-8
+#, coding=utf-8
 # Copyright 2018 The Tensor2Tensor Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -1433,7 +1433,8 @@ def dot_product_attention(q,
                           name=None,
                           make_image_summary=True,
                           save_weights_to=None,
-                          dropout_broadcast_dims=None):
+                          dropout_broadcast_dims=None,
+                          probability_fn=tf.nn.softmax):
   """Dot-product attention.
 
   Args:
@@ -1453,6 +1454,8 @@ def dot_product_attention(q,
       a string key created from the variable scope (including name).
     dropout_broadcast_dims: an optional list of integers less than rank of q.
       Specifies in which dimensions to broadcast the dropout decisions.
+    probability_fn: function used to transform the logits into a probability
+        distribution i.e. the attention weights.
 
   Returns:
     Tensor with shape [..., length_q, depth_v].
@@ -1463,7 +1466,7 @@ def dot_product_attention(q,
     if bias is not None:
       bias = common_layers.cast_like(bias, logits)
       logits += bias
-    weights = tf.nn.softmax(logits, name="attention_weights")
+    weights = probability_fn(logits, name="attention_weights")
     if save_weights_to is not None:
       save_weights_to[scope.name] = weights
       save_weights_to[scope.name + "/logits"] = logits

--- a/tensor2tensor/layers/common_attention.py
+++ b/tensor2tensor/layers/common_attention.py
@@ -1,4 +1,4 @@
-#, coding=utf-8
+# coding=utf-8
 # Copyright 2018 The Tensor2Tensor Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");

--- a/tensor2tensor/layers/modalities.py
+++ b/tensor2tensor/layers/modalities.py
@@ -163,7 +163,7 @@ class SymbolModality(modality.Modality):
         # is the expected shape of [B, 1, D]
         # https://github.com/tensorflow/tensor2tensor/blob/d600c8bb196193596fdb38c2b6e5393c4e240564/tensor2tensor/layers/modalities.py#L1135
         return tf.reshape(logits,
-                          body_output_shape[:-1] + [1, self._vocab_size])
+                          body_output_shape[:-1] + [1, var.shape[0]])
 
 
 class SymbolModalityWeightsAll(SymbolModality):


### PR DESCRIPTION
https://app.asana.com/0/1202226313019611/1202440648394133/f

To enable running `top()` using different subsets of the vocab weights tensor (for https://github.com/medicode/diseaseTools/pull/18422), we need the _pooled vector_ X _vocab weights_ logic to be flexible and infer the expected size from the weights tensor it's using rather than it being hardcoded to the full vocab size.

Test plan:
- [x] ran an MVER with label partitioned model
- [x] ran inference with a production model, verified that it didn't fatal and output reasonable logits